### PR TITLE
Fix motion vector decoding

### DIFF
--- a/src/decodeframe.cs
+++ b/src/decodeframe.cs
@@ -288,7 +288,15 @@ namespace Vpx.Net
             {
                 /* Various keyframe initializations */
                 //memcpy(pc->fc.mvc, vp8_default_mv_context, sizeof(vp8_default_mv_context));
-                Array.Copy(entropymv.vp8_default_mv_context, pc.fc.mvc, entropymv.vp8_default_mv_context.Length);
+                for (int i = 0; i < entropymv.vp8_default_mv_context.Length; i++)
+                {
+                    pc.fc.mvc[i] = new MV_CONTEXT();
+
+                    for (int j = 0; j < entropymv.vp8_default_mv_context[i].prob.Length; j++)
+                    {
+                        pc.fc.mvc[i].prob[j] = entropymv.vp8_default_mv_context[i].prob[j];
+                    }
+                }
 
                 entropymode.vp8_init_mbmode_probs(pc);
 

--- a/src/decodemv.cs
+++ b/src/decodemv.cs
@@ -35,15 +35,15 @@ namespace Vpx.Net
     {
         enum MB_MODES { CNT_INTRA, CNT_NEAREST, CNT_NEAR, CNT_SPLITMV };
 
-        static readonly vp8_prob[,] vp8_sub_mv_ref_prob3 = new vp8_prob[8, blockd.VP8_SUBMVREFS - 1] {
-          { 147, 136, 18 }, /* SUBMVREF_NORMAL          */
-          { 223, 1, 34 },   /* SUBMVREF_LEFT_ABOVE_SAME */
-          { 106, 145, 1 },  /* SUBMVREF_LEFT_ZED        */
-          { 208, 1, 1 },    /* SUBMVREF_LEFT_ABOVE_ZED  */
-          { 179, 121, 1 },  /* SUBMVREF_ABOVE_ZED       */
-          { 223, 1, 34 },   /* SUBMVREF_LEFT_ABOVE_SAME */
-          { 179, 121, 1 },  /* SUBMVREF_ABOVE_ZED       */
-          { 208, 1, 1 }     /* SUBMVREF_LEFT_ABOVE_ZED  */
+        static readonly vp8_prob[][] vp8_sub_mv_ref_prob3 = new vp8_prob[8][] {
+          new vp8_prob[blockd.VP8_SUBMVREFS - 1] { 147, 136, 18 }, /* SUBMVREF_NORMAL          */
+          new vp8_prob[blockd.VP8_SUBMVREFS - 1] { 223, 1, 34 },   /* SUBMVREF_LEFT_ABOVE_SAME */
+          new vp8_prob[blockd.VP8_SUBMVREFS - 1] { 106, 145, 1 },  /* SUBMVREF_LEFT_ZED        */
+          new vp8_prob[blockd.VP8_SUBMVREFS - 1] { 208, 1, 1 },    /* SUBMVREF_LEFT_ABOVE_ZED  */
+          new vp8_prob[blockd.VP8_SUBMVREFS - 1] { 179, 121, 1 },  /* SUBMVREF_ABOVE_ZED       */
+          new vp8_prob[blockd.VP8_SUBMVREFS - 1] { 223, 1, 34 },   /* SUBMVREF_LEFT_ABOVE_SAME */
+          new vp8_prob[blockd.VP8_SUBMVREFS - 1] { 179, 121, 1 },  /* SUBMVREF_ABOVE_ZED       */
+          new vp8_prob[blockd.VP8_SUBMVREFS - 1] { 208, 1, 1 }     /* SUBMVREF_LEFT_ABOVE_ZED  */
         };
 
         static readonly byte[] mbsplit_fill_count = { 8, 8, 4, 1 };
@@ -336,7 +336,7 @@ namespace Vpx.Net
                 /* Process above */
                 if (above.get().mbmi.ref_frame != (byte)MV_REFERENCE_FRAME.INTRA_FRAME)
                 {
-                    if (above.get().mbmi.mv.as_int > 0)
+                    if (above.get().mbmi.mv.as_int != 0)
                     {
                         (++nmv)->as_int = above.get().mbmi.mv.as_int;
                         findnearmv.mv_bias(ref_frame_sign_bias[above.get().mbmi.ref_frame], mbmi.ref_frame,
@@ -350,7 +350,7 @@ namespace Vpx.Net
                 /* Process left */
                 if (left.get().mbmi.ref_frame != (byte)MV_REFERENCE_FRAME.INTRA_FRAME)
                 {
-                    if (left.get().mbmi.mv.as_int > 0)
+                    if (left.get().mbmi.mv.as_int != 0)
                     {
                         int_mv this_mv = new int_mv();
 
@@ -375,7 +375,7 @@ namespace Vpx.Net
                 /* Process above left */
                 if (aboveleft.get().mbmi.ref_frame != (byte)MV_REFERENCE_FRAME.INTRA_FRAME)
                 {
-                    if (aboveleft.get().mbmi.mv.as_int > 0)
+                    if (aboveleft.get().mbmi.mv.as_int != 0)
                     {
                         int_mv this_mv = new int_mv();
 
@@ -437,14 +437,14 @@ namespace Vpx.Net
                             mb_to_left_edge -= findnearmv.LEFT_TOP_MARGIN;
 
                             /* Use near_mvs[0] to store the "best" MV */
-                            near_index = (((int)MB_MODES.CNT_INTRA + (cnt[(int)MB_MODES.CNT_NEAREST]) >= cnt[(int)MB_MODES.CNT_INTRA])) ? 1 : 0;
+                            near_index = (int)MB_MODES.CNT_INTRA + (cnt[(int)MB_MODES.CNT_NEAREST] >= cnt[(int)MB_MODES.CNT_INTRA] ? 1 : 0);
 
                             findnearmv.vp8_clamp_mv2(ref near_mvs[near_index], in pbi.mb);
 
                             cnt[(int)MB_MODES.CNT_SPLITMV] =
                                 (((above.get().mbmi.mode == (int)MB_PREDICTION_MODE.SPLITMV) ? 1 : 0)
-                                + ((left.get().mbmi.mode == (int)MB_PREDICTION_MODE.SPLITMV) ? 1 : 0) * 2
-                                + ((aboveleft.get().mbmi.mode == (int)MB_PREDICTION_MODE.SPLITMV) ? 1 : 0));
+                                + ((left.get().mbmi.mode == (int)MB_PREDICTION_MODE.SPLITMV) ? 1 : 0)) * 2
+                                + ((aboveleft.get().mbmi.mode == (int)MB_PREDICTION_MODE.SPLITMV) ? 1 : 0);
 
                             if (treereader.vp8_read(ref bc, modecont.vp8_mode_contexts[cnt[(int)MB_MODES.CNT_SPLITMV], 3]) > 0)
                             {
@@ -646,7 +646,7 @@ namespace Vpx.Net
 
                 //vp8_prob* prob = get_sub_mv_ref_prob((int)leftmv.as_int, (int)abovemv.as_int);
                 int probIndex = get_sub_mv_ref_prob((int)leftmv.as_int, (int)abovemv.as_int);
-                var prob = vp8_sub_mv_ref_prob3.Cast<vp8_prob>().Skip(probIndex).ToArray();
+                var prob = vp8_sub_mv_ref_prob3[probIndex];
 
                 if (treereader.vp8_read(ref bc, prob[0]) > 0)
                 {
@@ -685,11 +685,11 @@ namespace Vpx.Net
                     uint fill_count = mbsplit_fill_count[s];
 
                     //fill_offset = &mbsplit_fill_offset[s,(byte)j * mbsplit_fill_count[s]];
-                    int fill_offset = mbsplit_fill_offset[s, (byte)j * mbsplit_fill_count[s]];
+                    int fill_offset = (byte)j * mbsplit_fill_count[s];
 
                     do
                     {
-                        mi.get().bmi[fill_offset].mv.as_int = blockmv.as_int;
+                        mi.get().bmi[mbsplit_fill_offset[s, fill_offset]].mv.as_int = blockmv.as_int;
                         fill_offset++;
                     } while (--fill_count > 0);
                 }


### PR DESCRIPTION
This fixes several bugs related to the decoding of motion vectors from the bitstream:
- `init_frame` would copy `vp8_default_mv_context` array references to the current context `mvc` field. When the probabilities are updated, the `vp8_default_mv_context` values would be modified too, since it copied the array references rather than the values within. This was fixed by creating a separate `MV_CONTEXT` and copying the values one by one using a loop. A better fix would probably be using fixed arrays, which is closer to what the original code does.
- Parenthesis at the wrong place on expression for `cnt[(int)MB_MODES.CNT_SPLITMV]` value. Original code had `(x + y) * 2` while yours had `(x + y * 2)` which produces a difference result (since multiplication takes precedence over addition).
- `var prob = vp8_sub_mv_ref_prob3.Cast<vp8_prob>().Skip(probIndex).ToArray();` is incorrect. The original code returns the array at `probIndex`, rather than skipping `probIndex` elements from base. Fixed by using a jagged array (btw, I noticed that the code uses bidimensional arrays instead of jagged arrays, not sure why).
- `get_sub_mv_ref_prob` was incorrect. On the original code, `fill_offset` was a displaced pointer to the `mbsplit_fill_offset` array. On yours, it is the value at that offset. Yours just increments that value, while the original would advance the pointer and read the next array element. Fixed by moving the array access inside the loop, and making `fill_offset` an array index instead. Could probably be made better by using jagged arrays too.

With those changes, the test videos I have here (mostly just some videos I converted to VP8) can now be decoded *mostly* correctly. Before most of them would just crash before displaying anything meaningful, or display a severely corrupted image.

Example:

https://user-images.githubusercontent.com/5624669/134959429-4f4ed904-5192-4b00-8034-b810ee771443.mp4

Before it would just crash with an access violation on `filter_block2d_first_pass`. I can include the video too if needed, but it is rather large. (This is just one of the blender open movies, so it shouldn't have problems with copyright or anything like that).

Note that it still has some issues (probably related to motion vectors still).

Other notes:

I noticed that in several places, it does `if (x > 0)` where the C code had `if (x)`. The correct would be `if (x != 0)`. If the value is unsigned it doesn't matter, but it can cause issues if the value is signed (and can ever be negative). So far I haven't found any problem caused by that, but it might be worth changing just to be on the safe side.
