### PR TITLE
Fix incorrect dequantization coefficients and structs passed by value rather than by ref

### DIFF
--- a/src/decodeframe.cs
+++ b/src/decodeframe.cs
@@ -1286,7 +1286,8 @@ namespace Vpx.Net
                                 {
                                     vp8_rtcd.vp8_dc_only_idct_add((short)(b.qcoeff.get() * DQC[0]), dst, dst_stride, dst, dst_stride);
                                     //memset(b.qcoeff, 0, 2 * sizeof(b.qcoeff[0]));
-                                    Mem.memset<short>(b.qcoeff.src(), 0, 2);
+                                    b.qcoeff.set(0, 0);
+                                    b.qcoeff.set(1, 0);
                                 }
                             }
                         }
@@ -1295,7 +1296,7 @@ namespace Vpx.Net
             }
             else
             {
-                reconinter.vp8_build_inter_predictors_mb(xd);
+                reconinter.vp8_build_inter_predictors_mb(ref xd);
             }
 
             if (xd.mode_info_context.get().mbmi.mb_skip_coeff == 0)

--- a/src/decodemv.cs
+++ b/src/decodemv.cs
@@ -448,7 +448,7 @@ namespace Vpx.Net
 
                             if (treereader.vp8_read(ref bc, modecont.vp8_mode_contexts[cnt[(int)MB_MODES.CNT_SPLITMV], 3]) > 0)
                             {
-                                decode_split_mv(ref bc, mi, left, above, mbmi, near_mvs[near_index],
+                                decode_split_mv(ref bc, mi, left, above, ref mbmi, near_mvs[near_index],
                                                 mvc, mb_to_left_edge, mb_to_right_edge,
                                                 mb_to_top_edge, mb_to_bottom_edge);
                                 mbmi.mv.as_int = mi.get().bmi[15].mv.as_int;
@@ -574,7 +574,7 @@ namespace Vpx.Net
 
         unsafe static void decode_split_mv(ref vp8_reader bc, ArrPtr<MODE_INFO> mi,
                                 in ArrPtr<MODE_INFO> left_mb, in ArrPtr<MODE_INFO> above_mb,
-                                MB_MODE_INFO mbmi, int_mv best_mv,
+                                ref MB_MODE_INFO mbmi, int_mv best_mv,
                                 in MV_CONTEXT[] mvc, int mb_to_left_edge,
                                 int mb_to_right_edge, int mb_to_top_edge,
                                 int mb_to_bottom_edge)

--- a/src/reconinter.cs
+++ b/src/reconinter.cs
@@ -146,7 +146,7 @@ namespace Vpx.Net
             }
         }
 
-        static void clamp_mv_to_umv_border(MV mv, MACROBLOCKD xd)
+        static void clamp_mv_to_umv_border(ref MV mv, MACROBLOCKD xd)
         {
             /* If the MV points so far into the UMV border that no visible pixels
              * are used for reconstruction, the subpel part of the MV can be
@@ -227,7 +227,7 @@ namespace Vpx.Net
             }
         }
 
-        static void vp8_build_inter16x16_predictors_mb(MACROBLOCKD x, byte* dst_y,
+        static void vp8_build_inter16x16_predictors_mb(ref MACROBLOCKD x, byte* dst_y,
                                             byte* dst_u,
                                             byte* dst_v, int dst_ystride,
                                             int dst_uvstride)
@@ -245,7 +245,7 @@ namespace Vpx.Net
 
             if (x.mode_info_context.get().mbmi.need_to_clamp_mvs > 0)
             {
-                clamp_mv_to_umv_border(_16x16mv.as_mv, x);
+                clamp_mv_to_umv_border(ref _16x16mv.as_mv, x);
             }
 
             ptr = ptr_base + (_16x16mv.as_mv.row >> 3) * pre_stride +
@@ -298,7 +298,7 @@ namespace Vpx.Net
             }
         }
 
-        static void build_inter4x4_predictors_mb(MACROBLOCKD x)
+        static void build_inter4x4_predictors_mb(ref MACROBLOCKD x)
         {
             int i;
             byte* base_dst = x.dst.y_buffer;
@@ -315,10 +315,10 @@ namespace Vpx.Net
                 x.block[10].bmi = x.mode_info_context.get().bmi[10];
                 if (x.mode_info_context.get().mbmi.need_to_clamp_mvs > 0)
                 {
-                    clamp_mv_to_umv_border(x.block[0].bmi.mv.as_mv, x);
-                    clamp_mv_to_umv_border(x.block[2].bmi.mv.as_mv, x);
-                    clamp_mv_to_umv_border(x.block[8].bmi.mv.as_mv, x);
-                    clamp_mv_to_umv_border(x.block[10].bmi.mv.as_mv, x);
+                    clamp_mv_to_umv_border(ref x.block[0].bmi.mv.as_mv, x);
+                    clamp_mv_to_umv_border(ref x.block[2].bmi.mv.as_mv, x);
+                    clamp_mv_to_umv_border(ref x.block[8].bmi.mv.as_mv, x);
+                    clamp_mv_to_umv_border(ref x.block[10].bmi.mv.as_mv, x);
                 }
 
                 b = x.block[0];
@@ -338,16 +338,16 @@ namespace Vpx.Net
             {
                 for (i = 0; i < 16; i += 2)
                 {
-                    BLOCKD d0 = x.block[i];
-                    BLOCKD d1 = x.block[i + 1];
+                    ref BLOCKD d0 = ref x.block[i];
+                    ref BLOCKD d1 = ref x.block[i + 1];
                     int dst_stride = x.dst.y_stride;
 
                     x.block[i + 0].bmi = x.mode_info_context.get().bmi[i + 0];
                     x.block[i + 1].bmi = x.mode_info_context.get().bmi[i + 1];
                     if (x.mode_info_context.get().mbmi.need_to_clamp_mvs > 0)
                     {
-                        clamp_mv_to_umv_border(x.block[i + 0].bmi.mv.as_mv, x);
-                        clamp_mv_to_umv_border(x.block[i + 1].bmi.mv.as_mv, x);
+                        clamp_mv_to_umv_border(ref x.block[i + 0].bmi.mv.as_mv, x);
+                        clamp_mv_to_umv_border(ref x.block[i + 1].bmi.mv.as_mv, x);
                     }
 
                     if (d0.bmi.mv.as_int == d1.bmi.mv.as_int)
@@ -368,8 +368,8 @@ namespace Vpx.Net
             base_pre = x.pre.u_buffer;
             for (i = 16; i < 20; i += 2)
             {
-                BLOCKD d0 = x.block[i];
-                BLOCKD d1 = x.block[i + 1];
+                ref BLOCKD d0 = ref x .block[i];
+                ref BLOCKD d1 = ref x .block[i + 1];
                 int dst_stride = x.dst.uv_stride;
 
                 /* Note: uv mvs already clamped in build_4x4uvmvs() */
@@ -392,8 +392,8 @@ namespace Vpx.Net
             base_pre = x.pre.v_buffer;
             for (i = 20; i < 24; i += 2)
             {
-                BLOCKD d0 = x.block[i];
-                BLOCKD d1 = x.block[i + 1];
+                ref BLOCKD d0 = ref x .block[i];
+                ref BLOCKD d1 = ref x .block[i + 1];
                 int dst_stride = x.dst.uv_stride;
 
                 /* Note: uv mvs already clamped in build_4x4uvmvs() */
@@ -413,7 +413,7 @@ namespace Vpx.Net
             }
         }
 
-        static void build_4x4uvmvs(MACROBLOCKD x)
+        static void build_4x4uvmvs(ref MACROBLOCKD x)
         {
             int i, j;
 
@@ -458,18 +458,18 @@ namespace Vpx.Net
             }
         }
 
-        public static void vp8_build_inter_predictors_mb(MACROBLOCKD xd)
+        public static void vp8_build_inter_predictors_mb(ref MACROBLOCKD xd)
         {
             if (xd.mode_info_context.get().mbmi.mode != (byte)MB_PREDICTION_MODE.SPLITMV)
             {
-                vp8_build_inter16x16_predictors_mb(xd, xd.dst.y_buffer, xd.dst.u_buffer,
+                vp8_build_inter16x16_predictors_mb(ref xd, xd.dst.y_buffer, xd.dst.u_buffer,
                                                    xd.dst.v_buffer, xd.dst.y_stride,
                                                    xd.dst.uv_stride);
             }
             else
             {
-                build_4x4uvmvs(xd);
-                build_inter4x4_predictors_mb(xd);
+                build_4x4uvmvs(ref xd);
+                build_inter4x4_predictors_mb(ref xd);
             }
         }
     }


### PR DESCRIPTION
- `Mem.memset<short>(b.qcoeff.src(), 0, 2);` is incorrect as it does not take `b.qcoeff.Index` into account and would always zero the base of the array. Fixed by using the `set` method that does take the index into account. Since it only sets 2 values to 0, it should be fine.
- `clamp_mv_to_umv_border` was basically a no-op because the first parameter struct (that it modifies) is passed by value. Fixed by passing it by reference.
- `BLOCKD d0 = x.block[i];` does not match the original code that stores a pointer to those elements. This causes issues since right after this it does `x.block[i + 0].bmi = x.mode_info_context.get().bmi[i + 0];` which is supposed to modify those values, but doesn't as it just stored a copy of the values. Fixed by using *ref locals* and storing a reference to them.
- `decode_split_mv` `nbmi` parameter was passed by value, which is not correct as the type is a struct, and the function modifies some of its fields, for example right at the end of the function it does `bmi.partitioning = (byte)s;`, but that value would be just lost as the struct was passed by value. Fixed by passing it by reference.

There's a few other cases where values were passed by reference on the original code, and by value here. I haven't actually found issues on all of them, but changed it anyway just for good measure, and because passing it by reference is better for performance, since the structs are rather large, and it would otherwise do costly stack copies.

With those changes, the remaining bugs I noticed on the video decoding here were fixed.
Before:

https://user-images.githubusercontent.com/5624669/134959429-4f4ed904-5192-4b00-8034-b810ee771443.mp4

After:

https://user-images.githubusercontent.com/5624669/135164418-e671437c-72e4-4e53-82cc-73d1b95920d8.mp4

Note that for the most part, I inspected them visually. I did hash and compare a few frames of one video and compare with libvpx output to ensure that they match, but I didn't do that for the entire video.


